### PR TITLE
add log4j configuration and service

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,10 @@ dependencies {
     implementation("com.github.vjames19.kotlin-futures:kotlin-futures-jdk8:1.2.0")
     implementation("io.github.cdimascio:dotenv-kotlin:6.4.1")
 
+    // logging and monitoring
+    implementation("org.apache.logging.log4j:log4j-api-kotlin:1.4.0")
+    implementation("org.apache.logging.log4j:log4j-core:2.23.1")
+
     testImplementation("io.kotest:kotest-runner-junit5:5.8.1")
     testImplementation("io.kotest:kotest-assertions-core:5.8.1")
     testImplementation("io.kotest:kotest-property:5.8.1")

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -3,13 +3,15 @@ package prod.prog
 import prod.prog.actionProperties.contextFactory.print.PrintDebug
 import prod.prog.actionProperties.contextFactory.print.PrintError
 import prod.prog.actionProperties.contextFactory.print.PrintInfo
+import prod.prog.actionProperties.contextFactory.print.PrintTrace
 import prod.prog.request.Request
 import prod.prog.request.RequestContext
 import prod.prog.request.resultHandler.IgnoreErrorHandler
 import prod.prog.request.resultHandler.IgnoreHandler
 import prod.prog.request.source.ConstantSource
 import prod.prog.request.transformer.IdTransformer
-import prod.prog.service.logger.ConsoleLogger
+import prod.prog.service.logger.log4j.Log4jLoggerService
+import prod.prog.service.logger.log4j.LogType
 import prod.prog.service.manager.TelegramBot
 import prod.prog.service.supervisor.Supervisor
 import prod.prog.service.supervisor.solver.EmptySolver
@@ -17,7 +19,8 @@ import prod.prog.service.supervisor.solver.actionSolver.LoggerSolver
 import prod.prog.service.supervisor.solver.requestSolver.SetUniqueIdSolver
 
 fun main() {
-    val logger = ConsoleLogger()
+    val logger = Log4jLoggerService(LogType.MESSAGES)
+    val telegramApiLogger = Log4jLoggerService(LogType.TELEGRAM_API)
 
     // инициализируем Supervisor двумя функциями - что делать перед и после каждого экшена
     // внутри Solver<Action> будут использоваться "тэги" - интерфейсы из package actionProperties
@@ -49,6 +52,10 @@ fun main() {
     // в выводе видно, что результат пришёл до начала срабатывания Handler
     logger.log(PrintInfo, "result: ${request.get(supervisor)}")
 
+    logger.log(PrintTrace, "trace")
+
+    telegramApiLogger.log(PrintInfo, "telegram api log")
+
     Thread.sleep(1_000)
 
     // в процессе работы можно изменять поведение Supervisor
@@ -62,6 +69,6 @@ fun main() {
     supervisor.before = LoggerSolver(logger, "started ", PrintDebug)
     supervisor.after = LoggerSolver(logger, "finished", PrintDebug)
 
-    val telegramBot = TelegramBot(supervisor, logger)
+    val telegramBot = TelegramBot(supervisor, telegramApiLogger)
     telegramBot.start()
 }

--- a/src/main/kotlin/actionProperties/contextFactory/print/PrintTrace.kt
+++ b/src/main/kotlin/actionProperties/contextFactory/print/PrintTrace.kt
@@ -1,0 +1,10 @@
+package prod.prog.actionProperties.contextFactory.print
+
+fun interface PrintTrace : PrintFatal {
+    override fun key() = PrintError()
+
+    companion object : PrintError {
+        operator fun invoke() = "PrintTrace"
+        override fun value() = "no message"
+    }
+}

--- a/src/main/kotlin/service/logger/log4j/Log4jLoggerService.kt
+++ b/src/main/kotlin/service/logger/log4j/Log4jLoggerService.kt
@@ -1,0 +1,34 @@
+package prod.prog.service.logger.log4j
+
+import org.apache.logging.log4j.kotlin.logger
+import prod.prog.actionProperties.contextFactory.print.*
+import prod.prog.service.logger.LoggerService
+
+class Log4jLoggerService(logType: LogType) : LoggerService {
+    private val logger = logger(logType.logName)
+
+    override fun name() = "Log4jLoggerService"
+
+    override fun log(logLevel: PrintFatal, message: String) {
+        when (logLevel) {
+            is PrintDebug -> {
+                logger.debug(message)
+            }
+            is PrintInfo -> {
+                logger.info(message)
+            }
+            is PrintWarning -> {
+                logger.warn(message)
+            }
+            is PrintError -> {
+                logger.error(message)
+            }
+            is PrintTrace -> {
+                logger.trace(message)
+            }
+            is PrintFatal -> {
+                logger.fatal(message)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/service/logger/log4j/LogType.kt
+++ b/src/main/kotlin/service/logger/log4j/LogType.kt
@@ -1,0 +1,6 @@
+package prod.prog.service.logger.log4j
+
+enum class LogType(val logName: String) {
+    MESSAGES("APPLICATION_MESSAGES.log"),
+    TELEGRAM_API("TELEGRAM_API.log"),
+}

--- a/src/main/kotlin/service/manager/TelegramBot.kt
+++ b/src/main/kotlin/service/manager/TelegramBot.kt
@@ -2,8 +2,11 @@ package prod.prog.service.manager
 
 import com.github.kotlintelegrambot.bot
 import com.github.kotlintelegrambot.dispatch
+import com.github.kotlintelegrambot.dispatcher.handlers.Handler
+import com.github.kotlintelegrambot.dispatcher.handlers.TextHandlerEnvironment
 import com.github.kotlintelegrambot.dispatcher.text
 import com.github.kotlintelegrambot.entities.ChatId
+import com.github.kotlintelegrambot.entities.Message
 import io.github.cdimascio.dotenv.dotenv
 import prod.prog.actionProperties.contextFactory.print.PrintInfo
 import prod.prog.request.resultHandler.IgnoreErrorHandler
@@ -13,7 +16,7 @@ import prod.prog.request.transformer.IdTransformer
 import prod.prog.service.logger.LoggerService
 import prod.prog.service.supervisor.Supervisor
 
-class TelegramBot(supervisor: Supervisor, var logger: LoggerService) : RequestManager(supervisor) {
+class TelegramBot(supervisor: Supervisor, private val logger: LoggerService) : RequestManager(supervisor) {
     override fun name() = "TelegramBot"
     private val telegramApiToken = dotenv()["TELEGRAM_API_TOKEN"]
     private val telegramApiAddress = dotenv()["TELEGRAM_API_ADDRESS"]
@@ -21,14 +24,7 @@ class TelegramBot(supervisor: Supervisor, var logger: LoggerService) : RequestMa
         token = telegramApiToken
         dispatch {
             text {
-                makeRequest(
-                    ConstantSource("hi, $text!"),
-                    IdTransformer(),
-                    IgnoreHandler(),
-                    IgnoreErrorHandler()
-                ).thenApply { res ->
-                    bot.sendMessage(ChatId.fromId(message.chat.id), text = res)
-                }
+                handleTextRequest()
             }
         }
     }
@@ -41,5 +37,24 @@ class TelegramBot(supervisor: Supervisor, var logger: LoggerService) : RequestMa
     override fun stop() {
         telegramBot.stopPolling()
         logger.log(PrintInfo, "polling stopped for $telegramApiAddress")
+    }
+
+    private fun TextHandlerEnvironment.handleTextRequest() {
+        val chatId = ChatId.fromId(message.chat.id)
+
+        logMessage(message)
+
+        makeRequest(
+            ConstantSource("hi, $text!"),
+            IdTransformer(),
+            IgnoreHandler(),
+            IgnoreErrorHandler()
+        ).thenApply { res ->
+            bot.sendMessage(chatId, text = res)
+        }
+    }
+
+    private fun logMessage(message: Message) {
+        logger.log(PrintInfo, "Bot text request: [${message.text}], chatId: ${message.chat.id}, author: ${message.authorSignature}")
     }
 }

--- a/src/main/resources/log4j2-appenders.xml
+++ b/src/main/resources/log4j2-appenders.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Appenders>
+    <File name="MESSAGES" fileName="${sys:LOG_ROOT}/messages.log">
+        <PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss} [%t] %-5p %c{1}:%L - %msg%n"/>
+    </File>
+    <File name="REQUESTS" fileName="${sys:LOG_ROOT}/requests.log">
+        <PatternLayout pattern="%msg%n"/>
+    </File>
+    <Console name="CONSOLE" target="SYSTEM_OUT">
+        <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level - %msg%n"/>
+    </Console>
+</Appenders>

--- a/src/main/resources/log4j2-loggers.xml
+++ b/src/main/resources/log4j2-loggers.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Loggers>
+    <Root level="info">
+        <AppenderRef ref="CONSOLE"/>
+    </Root>
+    <Logger name="APPLICATION_MESSAGES.log" level="info" additivity="true">
+        <AppenderRef ref="MESSAGES"/>
+    </Logger>
+    <Logger name="TELEGRAM_API.log" level="info" additivity="true">
+        <AppenderRef ref="REQUESTS"/>
+    </Logger>
+</Loggers>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <Properties>
+        <Property name="LOG_ROOT">/log</Property>
+    </Properties>
+    <xi:include href="log4j2-loggers.xml"/>
+    <xi:include href="log4j2-appenders.xml"/>
+</Configuration>


### PR DESCRIPTION
Сделал примерную конфигурацию для log4j и логов
Так как могут быть разные логгеры (определяем по именам), стоит обращать внимание на то, какой логгер сервис передается в класс

Мониторинги пока не поддерживал, т.к. для этого нужно писать или подключать отдельные сервисы, а для этого стоит сначала правильно наше приложение в докере запустить и настроить где-то свою отдельную энву (т.е, иметь свою тачку или в клауде)

Вот статья про подключение таких сервисов с Prometheus + Grafana,  если интересно, но кажется сейчас мы нормально поднять такое не сможем
 https://habr.com/ru/articles/709204/